### PR TITLE
Trims trailing slashes from auth code

### DIFF
--- a/sdk/src/Client.js
+++ b/sdk/src/Client.js
@@ -305,6 +305,7 @@ var ADSKSpark = ADSKSpark || {};
 			if (isServer) {
 				var code = Helpers.extractRedirectionCode();
 				if (code) {
+					code = code.replace(/[\/\\]+$/, '');
 					return completeServerLogin(code);
 				}
 				return Promise.reject("No code supplied");

--- a/sdk/src/utilities/Helpers.js
+++ b/sdk/src/utilities/Helpers.js
@@ -27,10 +27,10 @@ var ADSKSpark = ADSKSpark || {};
 		 * @description - Transform parameter strings to array of params
 		 * @memberOf ADSKSpark.Helpers
 		 * @param {String} prmstr - The GET query string
-		 * @returns {Array} - Associative array of parameters
+		 * @returns {Object} - Associative array of parameters
 		 */
 		transformToAssocArray: function (prmstr) {
-			var params = [];
+			var params = {};
 
 			if (prmstr) {
 				var prmarr = prmstr.split('&');
@@ -47,12 +47,12 @@ var ADSKSpark = ADSKSpark || {};
 		 * @description - Extract params from URL
 		 * @memberOf ADSKSpark.Helpers
 		 * @param {String} prmstr - The GET query string
-		 * @returns {Array} - URL parameters
+		 * @returns {Object} - URL parameters
 		 */
 		extractParamsFromURL: function (prmstr) {
 			prmstr = prmstr || window.location.search.substr(1) || window.location.hash.substr(1);
 
-			return prmstr ? this.transformToAssocArray(prmstr) : [];
+			return prmstr ? this.transformToAssocArray(prmstr) : {};
 		},
 
 		/**


### PR DESCRIPTION
I'm getting auth callbacks that look like this:
http://localhost.autodesk.com:8000/?scope=DELETE%20READ%20WRITE&code=yvCNQbuU/
The trailing slash shouldn't be part of the code; otherwise, the auth fails
Trim it out, although this isn't ideal. Why is it happening at all? No callback url specified in dev portal.

Also: according to google coding guidelines, javascript arrays should not be used as associative arrays.
http://google.github.io/styleguide/javascriptguide.xml#Associative_Arrays

@gregra81