### PR TITLE
Improve handling of error response from Spark Drive.

### DIFF
--- a/sdk/src/utilities/Request.js
+++ b/sdk/src/utilities/Request.js
@@ -109,7 +109,18 @@ var ADSKSpark = ADSKSpark || {};
                         var error = new Error(xhr.statusText);
                         error.status = xhr.status;
                         error.statusText = xhr.statusText;
-                        error.responseText = xhr.responseText;
+                        if (xhr.responseType === 'arraybuffer') {
+                            var response = new Uint8Array(xhr.response);
+                            error.responseText = String.fromCharCode.apply(null, response);
+                            try {
+                                var err = JSON.parse(error.responseText);
+                                error = err;
+                            } catch(ex) {
+                            }
+                        }
+                        else {
+                            error.responseText = xhr.responseText;
+                        }
                         reject(error);
                     }
                 };


### PR DESCRIPTION
When an invalid file id is requested the response type is still arraybuffer
and the attempt to access responseText fails. Now check if the response
data parses as Json and return the result as the error object.

@gregra81 please merge if this looks ok. thx.